### PR TITLE
Updates to make it work for Amazon S3 and Digital Ocean Spaces

### DIFF
--- a/src/AWS/Core/Body.elm
+++ b/src/AWS/Core/Body.elm
@@ -7,11 +7,18 @@ import Json.Encode
 type Body
     = EmptyBody
     | JsonBody Json.Encode.Value
-
+    | HtmlBody String
+    | StringBody String String
 
 toHttp : Body -> Http.Body
 toHttp body =
     case body of
+        StringBody mimetype string ->
+            Http.stringBody mimetype string
+
+        HtmlBody string ->
+            Http.stringBody "text/html" string
+
         JsonBody value ->
             Http.jsonBody value
 
@@ -22,6 +29,12 @@ toHttp body =
 toString : Body -> String
 toString body =
     case body of
+        StringBody _ string ->
+            string
+
+        HtmlBody string ->
+            string
+
         JsonBody value ->
             Json.Encode.encode 0 value
 
@@ -37,3 +50,13 @@ empty =
 json : Json.Encode.Value -> Body
 json =
     JsonBody
+
+
+html : String -> Body
+html =
+    HtmlBody
+
+
+string : String -> String -> Body
+string =
+    StringBody

--- a/src/AWS/Core/Http.elm
+++ b/src/AWS/Core/Http.elm
@@ -11,6 +11,7 @@ module AWS.Core.Http
         , htmlBody
         , stringBody
         , request
+        , requestWithHeaders
         , responseData
         , send
         )
@@ -129,6 +130,20 @@ request :
     -> Request a
 request method =
     AWS.Core.Request.unsigned (toString method)
+
+
+{-| Create an AWS HTTP unsigned request with additional headers.
+-}
+requestWithHeaders :
+    Method
+    -> Query
+    -> Path
+    -> Query
+    -> Body
+    -> Json.Decode.Decoder a
+    -> Request a
+requestWithHeaders method =
+    AWS.Core.Request.unsignedWithHeaders (toString method)
 
 
 sign :

--- a/src/AWS/Core/Http.elm
+++ b/src/AWS/Core/Http.elm
@@ -124,7 +124,7 @@ sign :
 sign service creds date req =
     case Service.signer service of
         SignV4 ->
-            V4.sign service creds date req
+            Debug.log "signed req" <| V4.sign service creds date req
 
         SignV2 ->
             Debug.crash "Unsupported signature"

--- a/src/AWS/Core/Http.elm
+++ b/src/AWS/Core/Http.elm
@@ -8,6 +8,8 @@ module AWS.Core.Http
         , Response
         , emptyBody
         , jsonBody
+        , htmlBody
+        , stringBody
         , request
         , responseData
         , send
@@ -100,6 +102,20 @@ emptyBody =
 jsonBody : Json.Encode.Value -> Body
 jsonBody =
     AWS.Core.Body.json
+
+
+{-| Create a body containing an Html string
+-}
+htmlBody : String -> Body
+htmlBody =
+    AWS.Core.Body.html
+
+
+{-| Create a body containing a mimetype/String value.
+-}
+stringBody : String -> String -> Body
+stringBody =
+    AWS.Core.Body.string
 
 
 {-| Create an AWS HTTP unsigned request.

--- a/src/AWS/Core/Request.elm
+++ b/src/AWS/Core/Request.elm
@@ -9,6 +9,7 @@ import QueryString
 
 type alias Unsigned a =
     { method : String
+    , headers : List (String, String)
     , path : String
     , query : List ( String, String )
     , body : Body
@@ -26,6 +27,25 @@ unsigned :
 unsigned method uri query body decoder =
     Unsigned
         method
+        []
+        uri
+        query
+        body
+        decoder
+
+
+unsignedWithHeaders :
+    String
+    -> List ( String, String )
+    -> String
+    -> List ( String, String )
+    -> Body
+    -> Json.Decode.Decoder a
+    -> Unsigned a
+unsignedWithHeaders method headers uri query body decoder =
+    Unsigned
+        method
+        headers
         uri
         query
         body

--- a/src/AWS/Core/Service.elm
+++ b/src/AWS/Core/Service.elm
@@ -395,7 +395,7 @@ region (Service { endpoint, isDigitalOcean }) =
 
         GlobalEndpoint ->
             if isDigitalOcean then
-                "ny3c"
+                "nyc3"
             else
                 -- See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
                 "us-east-1"

--- a/src/AWS/Core/Service.elm
+++ b/src/AWS/Core/Service.elm
@@ -14,6 +14,7 @@ module AWS.Core.Service
         , iso8601
         , json
         , jsonContentType
+        , acceptType
         , query
         , region
         , restJson
@@ -85,7 +86,7 @@ These functions are exposed so that [AWS.Core.Http](AWS-Core-Http) can properly
 sign requests. They can be useful for debugging, testing, and logging, but
 otherwise are not required.
 
-@docs endpointPrefix, region, host, signer, targetPrefix, jsonContentType
+@docs endpointPrefix, region, host, signer, targetPrefix, jsonContentType, acceptType
 
 -}
 
@@ -310,16 +311,28 @@ signer (Service { signer }) =
 {-| Gets the service JSON content type header value.
 -}
 jsonContentType : Service -> String
-jsonContentType (Service { jsonVersion }) =
-    (case jsonVersion of
-        Just apiVersion ->
-            "application/x-amz-json-" ++ apiVersion
+jsonContentType (Service { protocol, jsonVersion }) =
+    (if protocol == restXml then
+         "application/xml"
+     else
+         case jsonVersion of
+             Just apiVersion ->
+                 "application/x-amz-json-" ++ apiVersion
 
-        Nothing ->
-            "application/json"
+             Nothing ->
+                 "application/json"
     )
         ++ "; charset=utf-8"
 
+
+{-| Gets the service Accept header value.
+-}
+acceptType : Service -> String
+acceptType (Service { protocol }) =
+    if protocol == restXml then
+        "application/xml"
+    else
+        "application/json"
 
 
 -- ENDPOINTS

--- a/src/AWS/Core/Signers/V4.elm
+++ b/src/AWS/Core/Signers/V4.elm
@@ -46,7 +46,7 @@ algorithm =
 
 headers : Service -> List ( String, String )
 headers service =
-    [ ( "Accept", "application/json" )
+    [ ( "Accept", Service.acceptType service )
     , ( "Content-Type", Service.jsonContentType service )
     ]
 

--- a/src/AWS/Core/Signers/V4.elm
+++ b/src/AWS/Core/Signers/V4.elm
@@ -27,7 +27,7 @@ sign service creds date req =
     Http.request
         { method = req.method
         , headers =
-            headers service date req.body
+            headers service date req.body req.headers
                 |> addAuthorization service creds date req
                 |> addSessionToken creds
                 |> List.map (\( key, val ) -> Http.header key val)
@@ -44,13 +44,15 @@ algorithm =
     "AWS4-HMAC-SHA256"
 
 
-headers : Service -> Date -> Body -> List ( String, String )
-headers service date body =
-    [ ( "x-amz-date", formatDate date )
-    , ( "x-amz-content-sha256", canonicalPayload body )
-    , ( "Accept", Service.acceptType service )
-    , ( "Content-Type", Service.jsonContentType service )
-    ]
+headers : Service -> Date -> Body -> List ( String, String ) -> List ( String, String )
+headers service date body extraHeaders =
+    List.append
+        extraHeaders
+        [ ( "x-amz-date", formatDate date )
+        , ( "x-amz-content-sha256", canonicalPayload body )
+        , ( "Accept", Service.acceptType service )
+        , ( "Content-Type", Service.jsonContentType service )
+        ]
 
 
 formatDate : Date -> String

--- a/src/AWS/Core/Signers/V4.elm
+++ b/src/AWS/Core/Signers/V4.elm
@@ -97,6 +97,16 @@ addAuthorization service creds date req headers =
         |> List.append headers
 
 
+-- Expects headersToRemove to be all lower-case
+filterHeaders : List String -> List ( String, String ) -> List ( String, String )
+filterHeaders headersToRemove headers =
+    let matches = (\(head, _) ->
+                     not <| List.member (String.toLower head) headersToRemove
+                  )
+    in
+        List.filter matches headers
+                    
+
 authorization :
     Credentials
     -> Date
@@ -104,8 +114,10 @@ authorization :
     -> Unsigned a
     -> List ( String, String )
     -> String
-authorization creds date service req headers =
+authorization creds date service req rawHeaders =
     let
+        -- Content-Type & Accept tend to be amended by Http.request
+        headers = filterHeaders ["content-type", "accept"] rawHeaders
         canon =
             canonical req.method req.path headers req.query req.body
 


### PR DESCRIPTION
https://github.com/billstclair/elm-s3 contains a working example based on these changes. It is now able to list bucket contents, and read, write, and delete objects.

The commit messages should make it pretty clear what I had to change. There were three basic things:

1) Generalize the `Service.host` and `Service.region` functions, so that they can return the proper strings for Digital Ocean Spaces. The defaults are still for Amazon S3, so existing code shouldn't have to change.

2) Fix the signed headers. I added `x-amz-date` and `x-amz-content-sha256` and removed `Content-Type` and `Accept`.

3) Add `StringBody` and `HtmlBody` types and functions to create them. Add `Http.requestWithHeaders`, so that the user can specify a canned ACL with `S3.putObject`.

`billstclair/elm-s3` is usable now. I'd love to be able to publish it to the Elm repository, but I need you to publish `ktonen/elm-aws-core` before I can do that.