### PR TITLE
Fix the 'Content-Type' headers sent with a request.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,10 @@ See [Editor Integration](https://github.com/avh4/elm-format#editor-integration) 
 Please ensure that the tests succeed before you create a pull request.
 
 ```shell
+# Do once
+npm install -g elm-doc-test@4.0.0 elm-test@0.18.10
+
+# Do before every pull request
 cd .../elm-aws-core
-elm-doc-test
-elm-test
+elm-make --docs=docs.json && elm-doc-test && elm-test
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,13 @@ npm install -g elm-format@exp
 ```
 
 See [Editor Integration](https://github.com/avh4/elm-format#editor-integration) to run `elm-format` automatically whenever you save a file.
+
+## Testing
+
+Please ensure that the tests succeed before you create a pull request.
+
+```shell
+cd .../elm-aws-core
+elm-doc-test
+elm-test
+```

--- a/src/AWS/Core/Body.elm
+++ b/src/AWS/Core/Body.elm
@@ -2,8 +2,8 @@ module AWS.Core.Body
     exposing
         ( Body
         , empty
+        , explicitMimetype
         , json
-        , mimetype
         , string
         , toHttp
         , toString
@@ -32,8 +32,8 @@ toHttp body =
             Http.stringBody mimetype string
 
 
-mimetype : Body -> Maybe String
-mimetype body =
+explicitMimetype : Body -> Maybe String
+explicitMimetype body =
     case body of
         String typ _ ->
             Just typ

--- a/src/AWS/Core/Body.elm
+++ b/src/AWS/Core/Body.elm
@@ -3,6 +3,7 @@ module AWS.Core.Body
         ( Body
         , empty
         , json
+        , mimetype
         , string
         , toHttp
         , toString
@@ -29,6 +30,16 @@ toHttp body =
 
         String mimetype string ->
             Http.stringBody mimetype string
+
+
+mimetype : Body -> Maybe String
+mimetype body =
+    case body of
+        String typ _ ->
+            Just typ
+
+        _ ->
+            Nothing
 
 
 toString : Body -> String

--- a/src/AWS/Core/Http.elm
+++ b/src/AWS/Core/Http.elm
@@ -11,6 +11,7 @@ module AWS.Core.Http
         , jsonBody
         , request
         , send
+        , setResponseParser
         , stringBody
         )
 
@@ -29,7 +30,7 @@ Examples assume the following imports:
 
 # Requests
 
-@docs Request, request, addHeaders, addQuery, send, Method, Path
+@docs Request, request, addHeaders, addQuery, setResponseParser, send, Method, Path
 
 
 # Body
@@ -168,6 +169,13 @@ addHeaders headers req =
 addQuery : List ( String, String ) -> Request a -> Request a
 addQuery query req =
     { req | query = List.append req.query query }
+
+
+{-| Set a parser for the entire Http.Response. Overrides the request decoder.
+-}
+setResponseParser : Maybe (Http.Response String -> Result String a) -> Request a -> Request a
+setResponseParser parser req =
+    { req | responseParser = parser }
 
 
 {-| Signs and sends an AWS Request.

--- a/src/AWS/Core/Http.elm
+++ b/src/AWS/Core/Http.elm
@@ -120,7 +120,7 @@ stringBody =
 
     request GET "/" emptyBody Json.Decode.value
         |> toString
-    --> "{ method = \"GET\", path = \"/\", body = Empty, decoder = <decoder>, headers = [], query = [] }"
+    --> "{ method = \"GET\", path = \"/\", body = Empty, decoder = <decoder>, headers = [], query = [], responseParser = Nothing }"
 
 -}
 request :
@@ -144,7 +144,7 @@ request method =
             [ ( "x-custom-3", "value 3" )
             ]
         |> toString
-    --> "{ method = \"GET\", path = \"/\", body = Empty, decoder = <decoder>, headers = [(\"x-custom-1\",\"value 1\"),(\"x-Custom-2\",\"value 2\"),(\"x-custom-3\",\"value 3\")], query = [] }"
+    --> "{ method = \"GET\", path = \"/\", body = Empty, decoder = <decoder>, headers = [(\"x-custom-1\",\"value 1\"),(\"x-Custom-2\",\"value 2\"),(\"x-custom-3\",\"value 3\")], query = [], responseParser = Nothing }"
 
 -}
 addHeaders : List ( String, String ) -> Request a -> Request a
@@ -163,7 +163,7 @@ addHeaders headers req =
             [ ( "key3", "value 3" )
             ]
         |> toString
-    --> "{ method = \"GET\", path = \"/\", body = Empty, decoder = <decoder>, headers = [], query = [(\"key1\",\"value 1\"),(\"Key2\",\"value 2\"),(\"key3\",\"value 3\")] }"
+    --> "{ method = \"GET\", path = \"/\", body = Empty, decoder = <decoder>, headers = [], query = [(\"key1\",\"value 1\"),(\"Key2\",\"value 2\"),(\"key3\",\"value 3\")], responseParser = Nothing }"
 
 -}
 addQuery : List ( String, String ) -> Request a -> Request a

--- a/src/AWS/Core/Http.elm
+++ b/src/AWS/Core/Http.elm
@@ -173,9 +173,9 @@ addQuery query req =
 
 {-| Set a parser for the entire Http.Response. Overrides the request decoder.
 -}
-setResponseParser : Maybe (Http.Response String -> Result String a) -> Request a -> Request a
+setResponseParser : (Http.Response String -> Result String a) -> Request a -> Request a
 setResponseParser parser req =
-    { req | responseParser = parser }
+    { req | responseParser = Just parser }
 
 
 {-| Signs and sends an AWS Request.

--- a/src/AWS/Core/Request.elm
+++ b/src/AWS/Core/Request.elm
@@ -9,6 +9,7 @@ module AWS.Core.Request
 import AWS.Core.Body as Body exposing (Body)
 import AWS.Core.Encode
 import AWS.Core.Service as Service exposing (Service)
+import Http
 import Json.Decode exposing (Decoder)
 import QueryString
 
@@ -20,6 +21,7 @@ type alias Unsigned a =
     , decoder : Decoder a
     , headers : List ( String, String )
     , query : List ( String, String )
+    , responseParser : Maybe (Http.Response String -> Result String a)
     }
 
 
@@ -37,6 +39,7 @@ unsigned method uri body decoder =
         decoder
         []
         []
+        Nothing
 
 
 url : Service -> Unsigned a -> String

--- a/src/AWS/Core/Signers/V4.elm
+++ b/src/AWS/Core/Signers/V4.elm
@@ -33,7 +33,13 @@ sign service creds date req =
                 |> List.map (\( key, val ) -> Http.header key val)
         , url = AWS.Core.Request.url service req
         , body = AWS.Core.Body.toHttp req.body
-        , expect = Http.expectJson req.decoder
+        , expect =
+            case req.responseParser of
+                Just parser ->
+                    Http.expectStringResponse parser
+
+                Nothing ->
+                    Http.expectJson req.decoder
         , timeout = Nothing
         , withCredentials = False
         }

--- a/src/AWS/Core/Signers/V4.elm
+++ b/src/AWS/Core/Signers/V4.elm
@@ -1,6 +1,6 @@
 module AWS.Core.Signers.V4 exposing (..)
 
-import AWS.Core.Body exposing (Body, mimetype)
+import AWS.Core.Body exposing (Body, explicitMimetype)
 import AWS.Core.Credentials as Credentials exposing (Credentials)
 import AWS.Core.Request exposing (Unsigned)
 import AWS.Core.Service as Service exposing (Service)
@@ -27,7 +27,7 @@ sign service creds date req =
     Http.request
         { method = req.method
         , headers =
-            headers service date req.body (Debug.log "req.headers" req.headers)
+            headers service date req.body req.headers
                 |> addAuthorization service creds date req
                 |> addSessionToken creds
                 |> List.map (\( key, val ) -> Http.header key val)
@@ -66,7 +66,7 @@ headers service date body extraHeaders =
             []
           else
             [ ( "Accept", Service.acceptType service ) ]
-        , if List.member "content-type" extraNames || mimetype body /= Nothing then
+        , if List.member "content-type" extraNames || explicitMimetype body /= Nothing then
             []
           else
             [ ( "Content-Type", Service.jsonContentType service ) ]

--- a/tests/SignersTests/V4Tests.elm
+++ b/tests/SignersTests/V4Tests.elm
@@ -159,6 +159,7 @@ req data =
         (JD.succeed ())
         []
         data.query
+        Nothing
 
 
 


### PR DESCRIPTION
Only add a `Content-Type` to a request if the user hasn't overridden it and it's not in the `Body` (in which case, the Elm `Http` module adds another `Content-Type` header taken from there).

`elm-s3` needs this, since the `Content-Type` sent with a `PUT` request is stored with the object and returned when the object is read, either via the S3 interface, which discards headers, or via a standard `HTTP GET` to the public URL.

It might be nice to have some way to return the headers on an `S3 GET` request, but for publicly-readable objects, you can get those with an `HTTP HEAD` to the public URL, so it's not vital.